### PR TITLE
chore: add CI workflows and README badges

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,31 @@
+name: Backend CI (Maven)
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Build with Maven (skip tests)
+        run: mvn -q -DskipTests package
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-jar
+          path: target/*.jar

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,37 @@
+name: Frontend CI (Node)
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 18
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+          cache-dependency-path: 'frontend/package-lock.json'
+
+      - name: Install dependencies
+        run: npm ci || npm install
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-dist
+          path: frontend/dist

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Candidate Management System
 
+![Backend CI](https://github.com/Gaddamsaiom/candidate-management-system/actions/workflows/backend-ci.yml/badge.svg?branch=main)
+![Frontend CI](https://github.com/Gaddamsaiom/candidate-management-system/actions/workflows/frontend-ci.yml/badge.svg?branch=main)
+
 A simple, easy-to-understand Spring Boot + React application to submit and manage candidate profiles (freshers and experienced), including resume upload, search/filter, status updates, and JSON import/export.
+
+Repository: https://github.com/Gaddamsaiom/candidate-management-system
 
 ## Tech Stack
 - Backend: Spring Boot 3.5.6 (Java 21), Spring Web, Spring Data JPA, Validation, Lombok


### PR DESCRIPTION
This PR adds GitHub Actions CI for the backend (Maven) and frontend (Node/Vite), and updates README with build badges.\n\n- Backend CI: .github/workflows/backend-ci.yml\n- Frontend CI: .github/workflows/frontend-ci.yml\n- README: badges + repo link