### PR TITLE
Enable auto-merge for PRs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,21 @@
+name: Auto-enable auto-merge on PRs
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge (merge strategy)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh pr merge "$PR_NUMBER" --auto --merge --repo "$REPO"


### PR DESCRIPTION
Enables repository auto-merge and adds a workflow to automatically enable auto-merge on new/synced PRs. PRs will merge automatically after required checks (Backend CI, Frontend CI) pass.