### PR TITLE
Add plain commit guideline and PR labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,13 @@
+# Labeler rules for PRs
+# Requires actions/labeler workflow below
+
+frontend:
+  - 'frontend/**'
+
+backend:
+  - 'src/**'
+  - 'pom.xml'
+
+devx:
+  - '.github/**'
+  - 'tools/**'

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,21 @@
+name: Auto-enable auto-merge on PRs
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge (merge strategy)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh pr merge "$PR_NUMBER" --auto --merge --repo "$REPO"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,19 @@
+name: PR Labeler
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label PR
+        uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml

--- a/README.md
+++ b/README.md
@@ -91,3 +91,16 @@ CORS is already enabled for `http://localhost:5173` in `WebConfig`.
 mvn -q -DskipTests package
 ```
 Jar will be in `target/`.
+
+## Contributing Guidelines (Commits and PRs)
+
+- Use simple, plain commit messages. Examples:
+  - `Add manager page back button`
+  - `Fix search filter for status`
+  - `Update README with CI badges`
+- Workflow for changes:
+  1. Create a new branch from `main`.
+  2. Open a Pull Request (PR) to `main`.
+  3. Wait for CI to pass (Backend CI and Frontend CI).
+  4. Auto-merge will merge the PR once checks pass.
+


### PR DESCRIPTION
Adds README guidance for plain commit messages and a PR labeler workflow with labels: frontend, backend, devx.