### PR TITLE
Fix labeler config to actions/labeler@v5 syntax

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,13 +1,14 @@
-# Labeler rules for PRs
-# Requires actions/labeler workflow below
+# Labeler rules for PRs (actions/labeler@v5 syntax)
+# Docs: https://github.com/actions/labeler#common-examples
 
 frontend:
-  - 'frontend/**'
+  - changed-files:
+      - any-glob-to-any-file: ['frontend/**']
 
 backend:
-  - 'src/**'
-  - 'pom.xml'
+  - changed-files:
+      - any-glob-to-any-file: ['src/**','pom.xml']
 
 devx:
-  - '.github/**'
-  - 'tools/**'
+  - changed-files:
+      - any-glob-to-any-file: ['.github/**','tools/**']


### PR DESCRIPTION
Update .github/labeler.yml to v5 syntax (changed-files/any-glob-to-any-file) so PR Labeler passes.