### PR TITLE
ci: add backend smoke workflow to run jar and ping /api/manager on 8081

### DIFF
--- a/.github/workflows/backend-smoke.yml
+++ b/.github/workflows/backend-smoke.yml
@@ -1,0 +1,58 @@
+name: Backend Smoke (Run and Ping)
+
+on:
+  push:
+    branches: [ "feature/jsondb" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Build with Maven (skip tests)
+        run: mvn -q -DskipTests package
+
+      - name: Start application in background
+        run: |
+          nohup java -jar target/*.jar > app.log 2>&1 &
+          echo $! > app.pid
+
+      - name: Wait for app to be ready (retry)
+        run: |
+          for i in {1..30}; do
+            curl -sSf http://localhost:8081/api/manager > /dev/null && exit 0
+            sleep 2
+          done
+          echo "App did not become ready in time" >&2
+          echo "===== app.log (tail) ====="
+          tail -n 200 app.log || true
+          exit 1
+
+      - name: Smoke check /api/manager
+        run: |
+          curl -sS -D - http://localhost:8081/api/manager | head -n 20
+
+      - name: Show last app logs
+        if: always()
+        run: |
+          echo "===== app.log (tail) ====="
+          tail -n 200 app.log || true
+
+      - name: Stop application
+        if: always()
+        run: |
+          if [ -f app.pid ]; then
+            kill $(cat app.pid) || true
+          fi


### PR DESCRIPTION
## Summary

- What does this PR change?
- Why is this change needed?

## Checklist

- [ ] Branch created from `main` and up to date (`git pull --rebase origin main`)
- [ ] Build passes:
  - [ ] Backend CI (Maven)
  - [ ] Frontend CI (Node)
- [ ] Tests (if any) are updated/added
- [ ] README/docs updated if needed

## Screenshots (UI changes)

_Add screenshots or GIFs if the UI changed._

## Notes

_Add any additional context or follow-ups._
