### PR TITLE
ci: require 'auto-merge' label to enable automatic PR merge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,8 +1,8 @@
-name: Auto-enable auto-merge on PRs
+name: Auto-enable auto-merge on PRs (opt-in by label)
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [labeled, synchronize]
 
 permissions:
   contents: write
@@ -10,6 +10,8 @@ permissions:
 
 jobs:
   enable-auto-merge:
+    # Only run if the PR currently has a label named 'auto-merge'
+    if: contains(toJson(github.event.pull_request.labels), 'auto-merge')
     runs-on: ubuntu-latest
     steps:
       - name: Enable auto-merge (merge strategy)


### PR DESCRIPTION
## Summary

- What does this PR change?
- Why is this change needed?

## Checklist

- [ ] Branch created from `main` and up to date (`git pull --rebase origin main`)
- [ ] Build passes:
  - [ ] Backend CI (Maven)
  - [ ] Frontend CI (Node)
- [ ] Tests (if any) are updated/added
- [ ] README/docs updated if needed

## Screenshots (UI changes)

_Add screenshots or GIFs if the UI changed._

## Notes

_Add any additional context or follow-ups._
